### PR TITLE
Use EventLoopGroup instead of EventLoop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
 
   <artifactId>scalecube-reactor-aeron</artifactId>
-  <version>0.0.8</version>
+  <version>0.0.9-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>ScaleCube/scalecube-reactor-aeron</name>
@@ -18,7 +18,7 @@
     <connection>scm:git:git@github.com:scalecube/reactor-aeron.git</connection>
     <developerConnection>scm:git:git@github.com:scalecube/reactor-aeron.git
     </developerConnection>
-    <tag>v0.0.8</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/reactor-aeron-core/pom.xml
+++ b/reactor-aeron-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.scalecube</groupId>
     <artifactId>scalecube-reactor-aeron</artifactId>
-    <version>0.0.8</version>
+    <version>0.0.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>reactor-aeron-core</artifactId>

--- a/reactor-aeron-core/src/main/java/reactor/aeron/AeronEventLoop.java
+++ b/reactor-aeron-core/src/main/java/reactor/aeron/AeronEventLoop.java
@@ -231,7 +231,10 @@ public final class AeronEventLoop implements OnDisposable {
         try {
           publication.close();
         } catch (Exception ex) {
-          logger.warn("Exception occurred on closing publication: {}, cause: {}", publication, ex);
+          logger.warn(
+              "Exception occurred on closing publication: {}, cause: {}",
+              publication,
+              ex.toString());
         }
         it.remove();
       }
@@ -244,7 +247,9 @@ public final class AeronEventLoop implements OnDisposable {
           subscription.close();
         } catch (Exception ex) {
           logger.warn(
-              "Exception occurred on closing subscription: {}, cause: {}", subscription, ex);
+              "Exception occurred on closing subscription: {}, cause: {}",
+              subscription,
+              ex.toString());
         }
         it.remove();
       }

--- a/reactor-aeron-core/src/main/java/reactor/aeron/AeronEventLoop.java
+++ b/reactor-aeron-core/src/main/java/reactor/aeron/AeronEventLoop.java
@@ -17,6 +17,9 @@ import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoProcessor;
 import reactor.core.publisher.MonoSink;
 
+/**
+ * The worker.
+ */
 public final class AeronEventLoop implements OnDisposable {
 
   private static final Logger logger = LoggerFactory.getLogger(AeronEventLoop.class);
@@ -29,17 +32,25 @@ public final class AeronEventLoop implements OnDisposable {
 
   // Worker
   private final Mono<Worker> workerMono;
-  private volatile Thread thread;
-
   // Commands
   private final Queue<CommandTask> commandTasks = new ConcurrentLinkedQueue<>();
-
   private final List<MessagePublication> publications = new ArrayList<>();
   private final List<MessageSubscription> subscriptions = new ArrayList<>();
+  private volatile Thread thread;
 
   AeronEventLoop(IdleStrategy idleStrategy) {
     this.idleStrategy = idleStrategy;
     this.workerMono = Mono.fromCallable(this::createWorker).cache();
+  }
+
+  private static ThreadFactory defaultThreadFactory() {
+    return r -> {
+      Thread thread = new Thread(r);
+      thread.setName("aeron-event-loop");
+      thread.setUncaughtExceptionHandler(
+          (t, e) -> logger.error("Uncaught exception occurred: {}", e, e));
+      return thread;
+    };
   }
 
   private Worker createWorker() {
@@ -113,16 +124,6 @@ public final class AeronEventLoop implements OnDisposable {
     return onDispose.isDisposed();
   }
 
-  private static ThreadFactory defaultThreadFactory() {
-    return r -> {
-      Thread thread = new Thread(r);
-      thread.setName("aeron-event-loop");
-      thread.setUncaughtExceptionHandler(
-          (t, e) -> logger.error("Uncaught exception occurred: {}", e, e));
-      return thread;
-    };
-  }
-
   private Mono<Worker> worker() {
     return workerMono.takeUntilOther(listenDispose());
   }
@@ -136,6 +137,34 @@ public final class AeronEventLoop implements OnDisposable {
     return dispose //
         .map(avoid -> (T) avoid)
         .switchIfEmpty(Mono.error(Exceptions::failWithRejected));
+  }
+
+  /**
+   * Runnable task for submitting to {@link #commandTasks} queue. For usage see methods {@link
+   * #register(MessagePublication)} and {@link #dispose(MessagePublication)}.
+   */
+  private static class CommandTask implements Runnable {
+    private final MonoSink<Void> sink;
+    private final Consumer<MonoSink<Void>> consumer;
+
+    private CommandTask(MonoSink<Void> sink, Consumer<MonoSink<Void>> consumer) {
+      this.sink = sink;
+      this.consumer = consumer;
+    }
+
+    @Override
+    public void run() {
+      try {
+        consumer.accept(sink);
+      } catch (Exception ex) {
+        logger.warn("Exception occurred on command task: {}", ex);
+        sink.error(ex);
+      }
+    }
+
+    private void cancel() {
+      sink.error(Exceptions.failWithCancel());
+    }
   }
 
   /**
@@ -214,39 +243,11 @@ public final class AeronEventLoop implements OnDisposable {
         try {
           subscription.close();
         } catch (Exception ex) {
-          logger.warn("Exception occurred on closing subscription: {}, cause: {}",
-              subscription, ex);
+          logger.warn(
+              "Exception occurred on closing subscription: {}, cause: {}", subscription, ex);
         }
         it.remove();
       }
-    }
-  }
-
-  /**
-   * Runnable task for submitting to {@link #commandTasks} queue. For usage see methods {@link
-   * #register(MessagePublication)} and {@link #dispose(MessagePublication)}.
-   */
-  private static class CommandTask implements Runnable {
-    private final MonoSink<Void> sink;
-    private final Consumer<MonoSink<Void>> consumer;
-
-    private CommandTask(MonoSink<Void> sink, Consumer<MonoSink<Void>> consumer) {
-      this.sink = sink;
-      this.consumer = consumer;
-    }
-
-    @Override
-    public void run() {
-      try {
-        consumer.accept(sink);
-      } catch (Exception ex) {
-        logger.warn("Exception occurred on command task: {}", ex);
-        sink.error(ex);
-      }
-    }
-
-    private void cancel() {
-      sink.error(Exceptions.failWithCancel());
     }
   }
 }

--- a/reactor-aeron-core/src/main/java/reactor/aeron/AeronEventLoop.java
+++ b/reactor-aeron-core/src/main/java/reactor/aeron/AeronEventLoop.java
@@ -17,9 +17,6 @@ import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoProcessor;
 import reactor.core.publisher.MonoSink;
 
-/**
- * The worker.
- */
 public final class AeronEventLoop implements OnDisposable {
 
   private static final Logger logger = LoggerFactory.getLogger(AeronEventLoop.class);
@@ -32,10 +29,13 @@ public final class AeronEventLoop implements OnDisposable {
 
   // Worker
   private final Mono<Worker> workerMono;
+
   // Commands
   private final Queue<CommandTask> commandTasks = new ConcurrentLinkedQueue<>();
+
   private final List<MessagePublication> publications = new ArrayList<>();
   private final List<MessageSubscription> subscriptions = new ArrayList<>();
+
   private volatile Thread thread;
 
   AeronEventLoop(IdleStrategy idleStrategy) {

--- a/reactor-aeron-core/src/main/java/reactor/aeron/AeronEventLoopGroup.java
+++ b/reactor-aeron-core/src/main/java/reactor/aeron/AeronEventLoopGroup.java
@@ -1,0 +1,86 @@
+package reactor.aeron;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.agrona.concurrent.IdleStrategy;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.MonoProcessor;
+
+/**
+ * Wrapper around the {@link AeronEventLoop} where the actual logic is performed. Manages grouping
+ * of multiple instances of {@link AeronEventLoop}: round-robin iteration and grouped disposal.
+ */
+public class AeronEventLoopGroup implements OnDisposable {
+
+  // State:
+  private final AeronEventLoop[] eventLoops;
+  private final AtomicInteger idx = new AtomicInteger();
+  private final AtomicInteger terminatedWorkers = new AtomicInteger();
+  private final MonoProcessor<Void> onDispose = MonoProcessor.create();
+
+  /**
+   * Constructs an instance of {@link AeronEventLoopGroup} with number of workers equal to number of
+   * processors available to the JVM.
+   *
+   * @param idleStrategy - idle strategy to follow between work cycles
+   */
+  public AeronEventLoopGroup(IdleStrategy idleStrategy) {
+    this(idleStrategy, Runtime.getRuntime().availableProcessors());
+  }
+
+  /**
+   * Constructs an instance of {@link AeronEventLoopGroup}.
+   *
+   * @param idleStrategy idle strategy to follow between work cycles
+   * @param workers number of instances in group
+   */
+  public AeronEventLoopGroup(IdleStrategy idleStrategy, int workers) {
+    this.eventLoops = new AeronEventLoop[workers];
+    for (int i = 0; i < workers; i++) {
+      AeronEventLoop aeronEventLoop = new AeronEventLoop(idleStrategy);
+      // if only all workers disposed - dispose group
+      aeronEventLoop
+          .onDispose()
+          .subscribe(
+              disposed -> {
+                if (terminatedWorkers.incrementAndGet() == workers) {
+                  onDispose.onComplete();
+                }
+              });
+      eventLoops[i] = aeronEventLoop;
+    }
+  }
+
+  /**
+   * Get instance of worker from the group (round-robin iteration).
+   *
+   * @return instance of worker in the group
+   */
+  public AeronEventLoop next() {
+    return eventLoops[Math.abs(idx.getAndIncrement() % eventLoops.length)];
+  }
+
+  /**
+   * Completes successfully once all the workers in the group are disposed.
+   *
+   * @return mono that completes once workers are disposed
+   */
+  @Override
+  public Mono<Void> onDispose() {
+    return onDispose;
+  }
+
+  /** Dispose all the workers in group. */
+  @Override
+  public void dispose() {
+    if (!isDisposed()) {
+      for (AeronEventLoop worker : eventLoops) {
+        worker.dispose();
+      }
+    }
+  }
+
+  @Override
+  public boolean isDisposed() {
+    return onDispose.isDisposed();
+  }
+}

--- a/reactor-aeron-core/src/main/java/reactor/aeron/AeronResources.java
+++ b/reactor-aeron-core/src/main/java/reactor/aeron/AeronResources.java
@@ -137,7 +137,7 @@ public class AeronResources implements OnDisposable {
                   category,
                   AeronUtils.format(publication),
                   eventLoop,
-                  ex);
+                  ex.toString());
               if (!publication.isClosed()) {
                 publication.close();
               }
@@ -302,7 +302,7 @@ public class AeronResources implements OnDisposable {
                   category,
                   AeronUtils.format(subscription),
                   eventLoop,
-                  ex);
+                  ex.toString());
               if (!subscription.isClosed()) {
                 subscription.close();
               }

--- a/reactor-aeron-core/src/main/java/reactor/aeron/AeronResources.java
+++ b/reactor-aeron-core/src/main/java/reactor/aeron/AeronResources.java
@@ -133,7 +133,7 @@ public class AeronResources implements OnDisposable {
         .doOnError(
             ex -> {
               logger.error(
-                  "[{}] Failed to register publication {} on eventLoopGroup {}, cause: {}",
+                  "[{}] Failed to register publication {} on eventLoop {}, cause: {}",
                   category,
                   AeronUtils.format(publication),
                   eventLoop,
@@ -298,7 +298,7 @@ public class AeronResources implements OnDisposable {
         .doOnError(
             ex -> {
               logger.error(
-                  "[{}] Failed to register subscription {} on eventLoopGroup {}, cause: {}",
+                  "[{}] Failed to register subscription {} on eventLoop {}, cause: {}",
                   category,
                   AeronUtils.format(subscription),
                   eventLoop,

--- a/reactor-aeron-core/src/main/java/reactor/aeron/client/AeronClientConnector.java
+++ b/reactor-aeron-core/src/main/java/reactor/aeron/client/AeronClientConnector.java
@@ -205,7 +205,7 @@ public final class AeronClientConnector implements ControlMessageSubscriber, OnD
                   logger.warn(
                       "Failed to connect to server at {}, cause: {}",
                       AeronUtils.minifyChannel(serverChannel),
-                      ex));
+                      ex.toString()));
     }
 
     private Mono<Void> sendConnectRequest() {
@@ -254,7 +254,7 @@ public final class AeronClientConnector implements ControlMessageSubscriber, OnD
                       category,
                       messageType,
                       AeronUtils.minifyChannel(serverChannel),
-                      ex));
+                      ex.toString()));
     }
 
     @Override

--- a/reactor-aeron-tools/pom.xml
+++ b/reactor-aeron-tools/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.scalecube</groupId>
     <artifactId>scalecube-reactor-aeron</artifactId>
-    <version>0.0.8</version>
+    <version>0.0.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>reactor-aeron-tools</artifactId>


### PR DESCRIPTION
Create `AeronEventLoopGroup`. Must host internally an array of `AeronEventLoop`-s. 

Must impl. `OnDisposable` and provide public function `AeronEventLoop next()`.