### PR TITLE
Removed netty common with its Recycler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,11 +60,6 @@
         <artifactId>netty-buffer</artifactId>
         <version>${netty.version}</version>
       </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-common</artifactId>
-        <version>${netty.version}</version>
-      </dependency>
 
       <!-- Reactor Core -->
       <dependency>

--- a/reactor-aeron-core/pom.xml
+++ b/reactor-aeron-core/pom.xml
@@ -26,12 +26,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-common</artifactId>
-      <version>${netty.version}</version>
-    </dependency>
-
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>


### PR DESCRIPTION
Did not observe an improvement after using it (or improvement was so insignificant that I didn't observe it). IMHO not worth to have it as dependency. 
Overall, it's good idea to have objects pre-allocated and follow _get-then-use-then-return-to-the-shelf_  pattern, if we can create our own solution, then it would be great.