### PR TITLE
Fixed bitwise inversion for session id

### DIFF
--- a/reactor-aeron-benchmarks/src/main/java/reactor/aeron/pure/ClientThroughput.java
+++ b/reactor-aeron-benchmarks/src/main/java/reactor/aeron/pure/ClientThroughput.java
@@ -33,7 +33,7 @@ public class ClientThroughput {
       new ChannelUriStringBuilder()
           .controlEndpoint(Configurations.MDC_ADDRESS + ':' + CONTROL_PORT)
           .controlMode(CommonContext.MDC_CONTROL_MODE_DYNAMIC)
-          .sessionId(SESSION_ID ^ Integer.MAX_VALUE)
+          .sessionId(~SESSION_ID)
           .reliable(Boolean.TRUE)
           .media("udp")
           .build();

--- a/reactor-aeron-benchmarks/src/main/java/reactor/aeron/pure/MdcPing.java
+++ b/reactor-aeron-benchmarks/src/main/java/reactor/aeron/pure/MdcPing.java
@@ -50,7 +50,7 @@ public class MdcPing {
       new ChannelUriStringBuilder()
           .controlEndpoint(Configurations.MDC_ADDRESS + ':' + CONTROL_PORT)
           .controlMode(CommonContext.MDC_CONTROL_MODE_DYNAMIC)
-          .sessionId(SESSION_ID ^ Integer.MAX_VALUE)
+          .sessionId(~SESSION_ID)
           .reliable(Boolean.TRUE)
           .media("udp")
           .build();

--- a/reactor-aeron-benchmarks/src/main/java/reactor/aeron/pure/MdcPingAsync.java
+++ b/reactor-aeron-benchmarks/src/main/java/reactor/aeron/pure/MdcPingAsync.java
@@ -50,7 +50,7 @@ public class MdcPingAsync {
       new ChannelUriStringBuilder()
           .controlEndpoint(Configurations.MDC_ADDRESS + ':' + CONTROL_PORT)
           .controlMode(CommonContext.MDC_CONTROL_MODE_DYNAMIC)
-          .sessionId(SESSION_ID ^ Integer.MAX_VALUE)
+          .sessionId(~SESSION_ID)
           .reliable(Boolean.TRUE)
           .media("udp")
           .build();

--- a/reactor-aeron-benchmarks/src/main/java/reactor/aeron/pure/MdcPong.java
+++ b/reactor-aeron-benchmarks/src/main/java/reactor/aeron/pure/MdcPong.java
@@ -30,7 +30,7 @@ public class MdcPong {
   private static final String OUTBOUND_CHANNEL =
       new ChannelUriStringBuilder()
           .controlEndpoint(Configurations.MDC_ADDRESS + ':' + CONTROL_PORT)
-          .sessionId(SESSION_ID ^ Integer.MAX_VALUE)
+          .sessionId(~SESSION_ID)
           .media("udp")
           .reliable(Boolean.TRUE)
           .build();

--- a/reactor-aeron-benchmarks/src/main/java/reactor/aeron/pure/ServerThroughput.java
+++ b/reactor-aeron-benchmarks/src/main/java/reactor/aeron/pure/ServerThroughput.java
@@ -23,7 +23,7 @@ public class ServerThroughput {
   private static final String OUTBOUND_CHANNEL =
       new ChannelUriStringBuilder()
           .controlEndpoint(Configurations.MDC_ADDRESS + ':' + CONTROL_PORT)
-          .sessionId(SESSION_ID ^ Integer.MAX_VALUE)
+          .sessionId(~SESSION_ID)
           .media("udp")
           .reliable(Boolean.TRUE)
           .build();

--- a/reactor-aeron/src/main/java/reactor/aeron/AeronClientConnector.java
+++ b/reactor-aeron/src/main/java/reactor/aeron/AeronClientConnector.java
@@ -53,7 +53,7 @@ final class AeronClientConnector {
                     String inboundChannel =
                         options
                             .inboundUri()
-                            .uri(b -> b.sessionId(sessionId ^ Integer.MAX_VALUE))
+                            .uri(b -> b.sessionId(~sessionId))
                             .asString();
                     logger.debug(
                         "{}: creating client connection: {}",

--- a/reactor-aeron/src/main/java/reactor/aeron/AeronResources.java
+++ b/reactor-aeron/src/main/java/reactor/aeron/AeronResources.java
@@ -46,10 +46,7 @@ public final class AeronResources implements OnDisposable {
           .warnIfDirectoryExists(true)
           .dirDeleteOnStart(true)
           // low latency settings
-          .termBufferSparseFile(false)
-          // explicit range of reserved session ids
-          .publicationReservedSessionIdLow(0)
-          .publicationReservedSessionIdHigh(Integer.MAX_VALUE);
+          .termBufferSparseFile(false);
 
   private Supplier<IdleStrategy> workerIdleStrategySupplier = defaultBackoffIdleStrategySupplier;
 

--- a/reactor-aeron/src/main/java/reactor/aeron/AeronServerHandler.java
+++ b/reactor-aeron/src/main/java/reactor/aeron/AeronServerHandler.java
@@ -94,7 +94,7 @@ final class AeronServerHandler implements OnDisposable {
     // Pub(control-endpoint{address:serverControlPort}, xor(sessionId))->MDC(xor(sessionId))
     int sessionId = image.sessionId();
     String outboundChannel =
-        options.outboundUri().uri(b -> b.sessionId(sessionId ^ Integer.MAX_VALUE)).asString();
+        options.outboundUri().uri(b -> b.sessionId(~sessionId)).asString();
 
     logger.debug(
         "{}: creating server connection: {}", Integer.toHexString(sessionId), outboundChannel);

--- a/reactor-aeron/src/main/java/reactor/aeron/SecureRandomSessionIdGenerator.java
+++ b/reactor-aeron/src/main/java/reactor/aeron/SecureRandomSessionIdGenerator.java
@@ -17,6 +17,6 @@ public final class SecureRandomSessionIdGenerator implements Supplier<Integer> {
 
   @Override
   public Integer get() {
-    return random.nextInt(Integer.MAX_VALUE);
+    return random.nextInt();
   }
 }


### PR DESCRIPTION
Motivation:

For now, we apply, for bitwise inversion of session id, `Integer.MAX_VALUE`. And it equals to `0x7fffffff`, that means that all bit will be inverted apart from sign bit. It's wrong and we should use `0xffffffff` as a value or just bitwise inversion operator (`~`).